### PR TITLE
Add focus-visible ring to reader theme switch

### DIFF
--- a/static/styles/reader.css
+++ b/static/styles/reader.css
@@ -199,6 +199,11 @@ input[type='range'] {
   cursor: pointer;
 }
 
+.reader__theme-switch-input:focus-visible + .reader__theme-switch-track {
+  outline: 3px solid var(--reader-accent);
+  outline-offset: 3px;
+}
+
 .reader__theme-switch-track {
   position: relative;
   width: 48px;
@@ -248,6 +253,11 @@ input[type='range'] {
   height: 24px;
   top: 4px;
   left: 6px;
+}
+
+.reader__theme-switch--header .reader__theme-switch-input:focus-visible + .reader__theme-switch-track {
+  outline: 3px solid var(--reader-accent);
+  outline-offset: 3px;
 }
 
 .reader__theme-switch--header .reader__theme-switch-icon {


### PR DESCRIPTION
## Summary
- add a keyboard-only focus ring for the reader theme switch
- ensure the header theme switch variant also shows the same :focus-visible outline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cecaba3bf48321882b92ebf3e32ada