### PR TITLE
Refactor selection handling and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ See `docs/architecture.md` for detailed technical documentation covering:
 - Message passing and state management
 - Testing strategy
 
+### Coding Standards
+
+- `npm run lint` must pass; the ESLint config now enforces `space-in-parens` so padding spaces like `( selection` are reported (use `npm run lint:fix` for automatic cleanup).
+- `npm run typecheck` and `npm test` guard TypeScript types and Playwright scenarios respectively before submitting changes.
+- A Husky `pre-push` hook runs `npm run lint` and `npm run typecheck` automatically; if hooks are missing (e.g., after cloning), run `npm run prepare` to re-install them.
+
 ## <a name="license"></a>License
 
 Copyright (c) 2013-2025, Anthony Nosek

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ src/
   reader/          → RSVP player UI assembled from focused modules:
     index.ts            → Entrypoint that wires selection loading, controls, messaging.
     state.ts            → Central playback state container + shared helpers.
-    selection-loader.ts → Loads stored selection/preferences and syncs UI controls.
+    selection-loader.ts → Loads current selection/preferences and syncs UI controls.
     controls.ts         → DOM event bindings (playback, WPM slider, theme toggle, resize).
     playback.ts         → Timer management and playback progression.
     render.ts           → Word rendering, progress display, play/pause visuals.
@@ -80,11 +80,11 @@ scripts/build-extension.mjs → Esbuild-driven bundler & manifest generator.
 
 * Responsibilities
   * Tracks the latest selection synchronised from content scripts.
-  * Persists reader preferences and the most recent page selection via `storage.ts` helpers. Manual popup input is not persisted and is only used for the active reader session.
+  * Persists reader preferences via `storage.ts` helpers. Text selections are not persisted and each reader session uses fresh input data.
   * Owns the reader window lifecycle (`openReaderWindowSetup`) and exposes the function on `globalThis` for Playwright automation and integration tests.
   * Generates context-menu commands and keyboard shortcuts that route back into the shared open-reader workflow.
   * Normalises install/update flows by opening the welcome/updated pages from `static/pages`.
-  * Delegates responsibilities to focused modules: `state.ts` (cached selection + prefs), `selection.ts` (storage sync), `reader-window.ts` (window lifecycle), `message-handler.ts` (runtime messages), and `listeners.ts` (events + commands).
+  * Delegates responsibilities to focused modules: `state.ts` (in-memory selection + prefs), `selection.ts` (state management), `reader-window.ts` (window lifecycle), `message-handler.ts` (runtime messages), and `listeners.ts` (events + commands).
 
 * Key collaborators
   * `BrowserAPI` shim to use `chrome.*` or `browser.*` without scattering feature detection.
@@ -109,7 +109,7 @@ The reader implementation follows a modular architecture with clear separation o
 
 #### 3.4.1 Bootstrap & Messaging (`src/reader/index.ts`, `selection-loader.ts`, `messages.ts`)
 * `index.ts` attaches a DOM-ready hook, then triggers selection loading, control registration, and runtime listener wiring.
-* `selection-loader.ts` fetches stored preferences/selection, normalises HTML, rebuilds timing chunks, and synchronises slider/theme UI.
+* `selection-loader.ts` fetches current preferences/selection, normalises HTML, rebuilds timing chunks, and synchronises slider/theme UI.
 * `messages.ts` listens for `refreshReader` runtime events and reuses the loader to refresh the view on demand.
 
 #### 3.4.2 State & Playback (`src/reader/state.ts`, `playback.ts`, `controls.ts`, `render.ts`, `text.ts`)
@@ -141,9 +141,9 @@ The reader implementation follows a modular architecture with clear separation o
 ## 4. Cross-Cutting Modules
 
 * `platform/browser.ts`: resolves the runtime API once, exposes a shared `browser` singleton, and uses wrapper helpers from `platform/types.ts` + `platform/wrap-chrome.ts` to collapse Chrome/Firefox/Safari differences.
-* `common/storage.ts`: wraps the callback-driven storage API with promise helpers, defines canonical keys, and centralises preference/selection persistence.
+* `common/storage.ts`: wraps the callback-driven storage API with promise helpers, defines canonical keys, and centralises preference persistence.
 * `common/messages.ts`: enumerates every structured message exchanged between contexts, enabling exhaustive checks during refactors.
-* `common/html.ts`: ensures consistent HTML encoding/decoding for stored selections and rendered reader output.
+* `common/html.ts`: ensures consistent HTML encoding/decoding for text selections and rendered reader output.
 * `common/theme.ts`: applies theme classes/dataset toggles so the popup and reader stay visually aligned.
 
 ## 5. Build & Packaging Pipeline

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,6 +133,7 @@ module.exports = [
         args: 'after-used',
         ignoreRestSiblings: false
       }],
+      'space-in-parens': ['error', 'never'],
       'no-unreachable': 'error',
       'no-unused-expressions': 'error',
       'n/no-missing-import': ['error', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-plugin-n": "^17.23.1",
         "eslint-plugin-promise": "^7.2.1",
         "eslint-plugin-sonarjs": "^3.0.5",
+        "husky": "^9.1.7",
         "typescript": "^5.9.2",
         "yazl": "^3.3.1"
       }
@@ -3084,6 +3085,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:chrome": "node ./scripts/build-extension.mjs chrome",
     "build:firefox": "node ./scripts/build-extension.mjs firefox",
     "build:safari": "node ./scripts/build-extension.mjs safari",
+    "prepare": "husky",
     "lint": "eslint src/ tests/ --ext .ts,.js",
     "lint:fix": "eslint src/ tests/ --ext .ts,.js --fix",
     "typecheck": "tsc --noEmit",
@@ -28,6 +29,7 @@
     "eslint-plugin-n": "^17.23.1",
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-sonarjs": "^3.0.5",
+    "husky": "^9.1.7",
     "typescript": "^5.9.2",
     "yazl": "^3.3.1"
   }

--- a/src/background/listeners.ts
+++ b/src/background/listeners.ts
@@ -9,11 +9,9 @@ import {
   setReaderWindowId,
   getSelectionState
 } from './state'
-import { ensureSelectionLoaded } from './selection'
 import { DEFAULTS } from '../config/defaults'
 
 async function handleInstall (details: chrome.runtime.InstalledDetails): Promise<void> {
-  await ensureSelectionLoaded()
   const version = browser.runtime.getManifest().version
   await setInStorage({ version })
 
@@ -45,7 +43,7 @@ async function createContextMenus (): Promise<void> {
 function registerContextMenuListener (): void {
   browser.contextMenus.onClicked.addListener(async (info: chrome.contextMenus.OnClickData) => {
     if (info.menuItemId === CONTEXT_MENU_ID && info.selectionText) {
-      await openReaderWindowSetup(true, info.selectionText, true, false)
+      await openReaderWindowSetup(info.selectionText, true, false)
     }
   })
 }
@@ -67,7 +65,7 @@ function registerCommandListener (): void {
 
     const latestSelection = getSelectionState()
     if (latestSelection.text.length > 0) {
-      await openReaderWindowSetup(true, latestSelection.text, latestSelection.hasSelection, latestSelection.isRTL)
+      await openReaderWindowSetup(latestSelection.text, latestSelection.hasSelection, latestSelection.isRTL)
       return
     }
 

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -3,7 +3,6 @@ import type { ReaderPreferences } from '../common/storage'
 import { CONTEXT_MENU_TITLE } from './constants'
 import { openReaderWindowSetup } from './reader-window'
 import {
-  ensureSelectionLoaded,
   selectionFromMessage
 } from './selection'
 import { getSelectionState } from './state'
@@ -13,10 +12,7 @@ import {
 } from './preferences'
 
 export async function primeBackgroundState (): Promise<void> {
-  await Promise.all([
-    ensureSelectionLoaded(),
-    ensurePreferencesLoaded()
-  ])
+  await ensurePreferencesLoaded()
 }
 
 export async function handleBackgroundMessage (
@@ -39,11 +35,11 @@ export async function handleBackgroundMessage (
       return true
     case 'openReaderFromContent':
       selectionFromMessage(message)
-      await openReaderWindowSetup(true, message.selectionText, message.haveSelection, message.dirRTL)
+      await openReaderWindowSetup(message.selectionText, message.haveSelection, message.dirRTL)
       // Informational: reader opened from content script
       return true
     case 'openReaderFromContextMenu':
-      await openReaderWindowSetup(true, message.selectionText, message.selectionText.length > 0, false)
+      await openReaderWindowSetup(message.selectionText, message.selectionText.length > 0, false)
       // Informational: reader opened from context menu
       return true
     case 'openReaderFromPopup': {
@@ -61,7 +57,7 @@ export async function handleBackgroundMessage (
         return true
       }
 
-      await openReaderWindowSetup(false, providedText, true, false)
+      await openReaderWindowSetup(providedText, true, false)
       // Informational: reader opened from popup
       return true
     }

--- a/src/background/reader-window.ts
+++ b/src/background/reader-window.ts
@@ -1,7 +1,6 @@
 import { browser } from '../platform/browser'
 import {
-  createSelection,
-  persistSelection
+  createSelection
 } from './selection'
 import {
   getReaderWindowId,
@@ -48,17 +47,11 @@ export async function openReaderWindow (): Promise<void> {
 }
 
 export async function openReaderWindowSetup (
-  saveToLocal: boolean,
   text: string,
   hasSelection: boolean,
   isRTL: boolean
 ): Promise<SelectionState> {
   const selection = createSelection(text, hasSelection, isRTL)
-
-  if (saveToLocal) {
-    await persistSelection(selection)
-  }
-
   await openReaderWindow()
   return selection
 }

--- a/src/background/selection.ts
+++ b/src/background/selection.ts
@@ -1,10 +1,4 @@
 import type { BackgroundMessage } from '../common/messages'
-import { decodeHtml, encodeHtml } from '../common/html'
-import {
-  readSelection,
-  writeSelection,
-  type StoredSelection
-} from '../common/storage'
 import {
   getSelectionState,
   setSelectionState,
@@ -12,38 +6,6 @@ import {
   type SelectionState
 } from './state'
 
-function toStoredSelection (selection: SelectionState): StoredSelection {
-  return {
-    text: encodeHtml(selection.text),
-    hasSelection: selection.hasSelection,
-    isRTL: selection.isRTL,
-    timestamp: selection.timestamp
-  }
-}
-
-function fromStoredSelection (selection: StoredSelection): SelectionState {
-  return {
-    text: decodeHtml(selection.text),
-    hasSelection: selection.hasSelection,
-    isRTL: selection.isRTL,
-    timestamp: selection.timestamp
-  }
-}
-
-export async function ensureSelectionLoaded (): Promise<SelectionState> {
-  const stored = await readSelection()
-  if (stored) {
-    const selection = fromStoredSelection(stored)
-    setSelectionState(selection)
-    return selection
-  }
-  return getSelectionState()
-}
-
-export async function persistSelection (selection: SelectionState): Promise<void> {
-  const storedSelection = toStoredSelection(selection)
-  await writeSelection(storedSelection)
-}
 
 export function selectionFromMessage (message: BackgroundMessage): SelectionState {
   const text = 'selectionText' in message && typeof message.selectionText === 'string'

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -1,12 +1,6 @@
 import { getBrowser } from '../platform/browser'
 import { getDefaultReaderPreferences } from '../config/defaults'
 
-export type StoredSelection = {
-  text: string;
-  hasSelection: boolean;
-  isRTL: boolean;
-  timestamp: number;
-};
 
 export type ReaderTheme = 'dark' | 'light';
 
@@ -61,20 +55,9 @@ export async function setInStorage (items: Record<string, unknown>): Promise<voi
 }
 
 export const STORAGE_KEYS = {
-  selection: 'sprintReader.selection',
   readerPrefs: 'sprintReader.readerPrefs'
 } as const
 
-export async function readSelection (): Promise<StoredSelection | undefined> {
-  const result = await getFromStorage<StoredSelection>([STORAGE_KEYS.selection])
-  return result[STORAGE_KEYS.selection]
-}
-
-export async function writeSelection (selection: StoredSelection): Promise<void> {
-  await setInStorage({
-    [STORAGE_KEYS.selection]: selection
-  })
-}
 
 export async function readReaderPreferences (): Promise<ReaderPreferences> {
   const result = await getFromStorage<ReaderPreferences>([STORAGE_KEYS.readerPrefs])

--- a/src/reader/selection-loader.ts
+++ b/src/reader/selection-loader.ts
@@ -1,4 +1,3 @@
-import { readSelection } from '../common/storage'
 import { loadPreferences } from './preferences'
 import { renderCurrentWord } from './render'
 import { state } from './state'
@@ -44,19 +43,8 @@ export async function loadSelectionContent (): Promise<void> {
   await loadPreferences()
   syncControls()
 
-  // Try to get current selection from background first (for popup text)
-  let selection = await getCurrentSelectionFromBackground()
-
-  // If no current selection or it's older than stored selection, use stored
-  if (!selection) {
-    selection = await readSelection()
-  } else {
-    // Compare with stored selection to use the more recent one
-    const storedSelection = await readSelection()
-    if (storedSelection && storedSelection.timestamp > selection.timestamp) {
-      selection = storedSelection
-    }
-  }
+  // Always get current selection from background (no persistence)
+  const selection = await getCurrentSelectionFromBackground()
 
   const rawText = selection?.text ? decodeHtml(selection.text) : ''
   const normalised = normaliseText(rawText)

--- a/tests/playwright/basic-functionality.spec.ts
+++ b/tests/playwright/basic-functionality.spec.ts
@@ -3,7 +3,6 @@ import { expect, test } from './fixtures';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -53,7 +52,6 @@ test.describe('Sprint Reader - Basic Functionality', () => {
             sendResponse?: (value?: unknown) => void,
           ) => boolean;
           openReaderWindowSetup: (
-            saveToLocal: boolean,
             text: string,
             haveSelection: boolean,
             directionRTL: boolean,
@@ -72,7 +70,7 @@ test.describe('Sprint Reader - Basic Functionality', () => {
           () => undefined,
         );
 
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: selectionText },
     );
@@ -110,7 +108,7 @@ test.describe('Sprint Reader - Basic Functionality', () => {
           throw new Error('openReaderWindowSetup is not available on the background worker');
         }
 
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: selectionText },
     );

--- a/tests/playwright/basic-functionality.spec.ts
+++ b/tests/playwright/basic-functionality.spec.ts
@@ -70,7 +70,7 @@ test.describe('Sprint Reader - Basic Functionality', () => {
           () => undefined,
         );
 
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: selectionText },
     );
@@ -108,7 +108,7 @@ test.describe('Sprint Reader - Basic Functionality', () => {
           throw new Error('openReaderWindowSetup is not available on the background worker');
         }
 
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: selectionText },
     );

--- a/tests/playwright/chunking-bug.spec.ts
+++ b/tests/playwright/chunking-bug.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from './fixtures';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -23,7 +22,7 @@ test.describe('Sprint Reader - Chunking Bug', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(false, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: testText },
     );
@@ -93,7 +92,7 @@ test.describe('Sprint Reader - Chunking Bug', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(false, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: testText },
     );

--- a/tests/playwright/chunking-bug.spec.ts
+++ b/tests/playwright/chunking-bug.spec.ts
@@ -22,7 +22,7 @@ test.describe('Sprint Reader - Chunking Bug', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: testText },
     );
@@ -92,7 +92,7 @@ test.describe('Sprint Reader - Chunking Bug', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: testText },
     );

--- a/tests/playwright/improved-word-grouping.spec.ts
+++ b/tests/playwright/improved-word-grouping.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from './fixtures';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -23,7 +22,7 @@ test.describe('Sprint Reader - Improved Word Grouping', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(false, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: testText },
     );
@@ -119,7 +118,7 @@ test.describe('Sprint Reader - Improved Word Grouping', () => {
       await background.evaluate(
         async ({ selection }) => {
           const scope = self as unknown as BackgroundContext;
-          await scope.openReaderWindowSetup(false, selection, true, false);
+          await scope.openReaderWindowSetup( selection, true, false);
         },
         { selection: testCase.text },
       );

--- a/tests/playwright/improved-word-grouping.spec.ts
+++ b/tests/playwright/improved-word-grouping.spec.ts
@@ -22,7 +22,7 @@ test.describe('Sprint Reader - Improved Word Grouping', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: testText },
     );
@@ -118,7 +118,7 @@ test.describe('Sprint Reader - Improved Word Grouping', () => {
       await background.evaluate(
         async ({ selection }) => {
           const scope = self as unknown as BackgroundContext;
-          await scope.openReaderWindowSetup( selection, true, false);
+          await scope.openReaderWindowSetup(selection, true, false);
         },
         { selection: testCase.text },
       );

--- a/tests/playwright/popup-caching-bug.spec.ts
+++ b/tests/playwright/popup-caching-bug.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from './fixtures';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -30,7 +29,7 @@ test.describe('Sprint Reader - Popup Caching Bug', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: cachedText },
     );
@@ -70,7 +69,7 @@ test.describe('Sprint Reader - Popup Caching Bug', () => {
       async ({ text }) => {
         const scope = self as unknown as BackgroundContext;
         // Simulate the popup's openReaderFromPopup message with saveToLocal: false
-        await scope.openReaderWindowSetup(false, text, true, false);
+        await scope.openReaderWindowSetup( text, true, false);
       },
       { text: popupText },
     );
@@ -118,7 +117,7 @@ test.describe('Sprint Reader - Popup Caching Bug', () => {
         async ({ text }) => {
           const scope = self as unknown as BackgroundContext;
           // Use saveToLocal: false like the real popup does
-          await scope.openReaderWindowSetup(false, text, true, false);
+          await scope.openReaderWindowSetup( text, true, false);
         },
         { text: currentText },
       );

--- a/tests/playwright/popup-caching-bug.spec.ts
+++ b/tests/playwright/popup-caching-bug.spec.ts
@@ -29,7 +29,7 @@ test.describe('Sprint Reader - Popup Caching Bug', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: cachedText },
     );
@@ -69,7 +69,7 @@ test.describe('Sprint Reader - Popup Caching Bug', () => {
       async ({ text }) => {
         const scope = self as unknown as BackgroundContext;
         // Simulate the popup's openReaderFromPopup message with saveToLocal: false
-        await scope.openReaderWindowSetup( text, true, false);
+        await scope.openReaderWindowSetup(text, true, false);
       },
       { text: popupText },
     );
@@ -117,7 +117,7 @@ test.describe('Sprint Reader - Popup Caching Bug', () => {
         async ({ text }) => {
           const scope = self as unknown as BackgroundContext;
           // Use saveToLocal: false like the real popup does
-          await scope.openReaderWindowSetup( text, true, false);
+          await scope.openReaderWindowSetup(text, true, false);
         },
         { text: currentText },
       );

--- a/tests/playwright/text-processing.spec.ts
+++ b/tests/playwright/text-processing.spec.ts
@@ -22,7 +22,7 @@ test.describe('Sprint Reader - Text Processing', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: testText },
     );

--- a/tests/playwright/text-processing.spec.ts
+++ b/tests/playwright/text-processing.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from './fixtures';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -23,7 +22,7 @@ test.describe('Sprint Reader - Text Processing', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: testText },
     );

--- a/tests/playwright/text-selection-and-popup.spec.ts
+++ b/tests/playwright/text-selection-and-popup.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from './fixtures';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -34,7 +33,7 @@ test.describe('Sprint Reader - Text Selection and Popup', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: firstText },
     );
@@ -78,7 +77,7 @@ test.describe('Sprint Reader - Text Selection and Popup', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: secondText },
     );
@@ -116,7 +115,7 @@ test.describe('Sprint Reader - Text Selection and Popup', () => {
       async ({ text }) => {
         const scope = self as unknown as BackgroundContext;
         // Simulate the popup's openReaderFromPopup message by directly calling the setup
-        await scope.openReaderWindowSetup(true, text, true, false);
+        await scope.openReaderWindowSetup( text, true, false);
       },
       { text: thirdText },
     );

--- a/tests/playwright/text-selection-and-popup.spec.ts
+++ b/tests/playwright/text-selection-and-popup.spec.ts
@@ -33,7 +33,7 @@ test.describe('Sprint Reader - Text Selection and Popup', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: firstText },
     );
@@ -77,7 +77,7 @@ test.describe('Sprint Reader - Text Selection and Popup', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: secondText },
     );
@@ -115,7 +115,7 @@ test.describe('Sprint Reader - Text Selection and Popup', () => {
       async ({ text }) => {
         const scope = self as unknown as BackgroundContext;
         // Simulate the popup's openReaderFromPopup message by directly calling the setup
-        await scope.openReaderWindowSetup( text, true, false);
+        await scope.openReaderWindowSetup(text, true, false);
       },
       { text: thirdText },
     );

--- a/tests/playwright/theme-switching.spec.ts
+++ b/tests/playwright/theme-switching.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from './fixtures';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -34,7 +33,7 @@ test.describe('Sprint Reader - Theme Switching', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: selectionText },
     );
@@ -157,7 +156,7 @@ test.describe('Sprint Reader - Theme Switching', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: selectionText },
     );

--- a/tests/playwright/theme-switching.spec.ts
+++ b/tests/playwright/theme-switching.spec.ts
@@ -33,7 +33,7 @@ test.describe('Sprint Reader - Theme Switching', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: selectionText },
     );
@@ -156,7 +156,7 @@ test.describe('Sprint Reader - Theme Switching', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: selectionText },
     );

--- a/tests/playwright/timing-algorithms.spec.ts
+++ b/tests/playwright/timing-algorithms.spec.ts
@@ -3,7 +3,6 @@ import { DEFAULTS } from '../../src/config/defaults';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -24,7 +23,7 @@ test.describe('Sprint Reader - Timing Algorithms', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: testText },
     );
@@ -89,7 +88,7 @@ test.describe('Sprint Reader - Timing Algorithms', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: testText },
     );

--- a/tests/playwright/timing-algorithms.spec.ts
+++ b/tests/playwright/timing-algorithms.spec.ts
@@ -23,7 +23,7 @@ test.describe('Sprint Reader - Timing Algorithms', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: testText },
     );
@@ -88,7 +88,7 @@ test.describe('Sprint Reader - Timing Algorithms', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: testText },
     );

--- a/tests/playwright/ui-positioning.spec.ts
+++ b/tests/playwright/ui-positioning.spec.ts
@@ -34,7 +34,7 @@ test.describe('Sprint Reader - UI Positioning', () => {
         if (typeof scope.openReaderWindowSetup !== 'function') {
           throw new Error('openReaderWindowSetup is not available on the background worker');
         }
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: selectionText },
     );

--- a/tests/playwright/ui-positioning.spec.ts
+++ b/tests/playwright/ui-positioning.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from './fixtures';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -35,7 +34,7 @@ test.describe('Sprint Reader - UI Positioning', () => {
         if (typeof scope.openReaderWindowSetup !== 'function') {
           throw new Error('openReaderWindowSetup is not available on the background worker');
         }
-        await scope.openReaderWindowSetup(true, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: selectionText },
     );

--- a/tests/playwright/word-grouping-debug.spec.ts
+++ b/tests/playwright/word-grouping-debug.spec.ts
@@ -3,7 +3,6 @@ import { DEFAULTS } from '../../src/config/defaults';
 
 type BackgroundContext = {
   openReaderWindowSetup: (
-    saveToLocal: boolean,
     text: string,
     haveSelection: boolean,
     directionRTL: boolean,
@@ -25,7 +24,7 @@ test.describe('Sprint Reader - Word Grouping Debug', () => {
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup(false, selection, true, false);
+        await scope.openReaderWindowSetup( selection, true, false);
       },
       { selection: testText },
     );
@@ -121,7 +120,7 @@ test.describe('Sprint Reader - Word Grouping Debug', () => {
       await background.evaluate(
         async ({ selection }) => {
           const scope = self as unknown as BackgroundContext;
-          await scope.openReaderWindowSetup(false, selection, true, false);
+          await scope.openReaderWindowSetup( selection, true, false);
         },
         { selection: testCase.text },
       );

--- a/tests/playwright/word-grouping-debug.spec.ts
+++ b/tests/playwright/word-grouping-debug.spec.ts
@@ -20,11 +20,11 @@ test.describe('Sprint Reader - Word Grouping Debug', () => {
       timeout: 10_000,
     });
 
-    // Use saveToLocal: false to simulate popup behavior
+    // Open reader window for this selection
     await background.evaluate(
       async ({ selection }) => {
         const scope = self as unknown as BackgroundContext;
-        await scope.openReaderWindowSetup( selection, true, false);
+        await scope.openReaderWindowSetup(selection, true, false);
       },
       { selection: testText },
     );
@@ -120,7 +120,7 @@ test.describe('Sprint Reader - Word Grouping Debug', () => {
       await background.evaluate(
         async ({ selection }) => {
           const scope = self as unknown as BackgroundContext;
-          await scope.openReaderWindowSetup( selection, true, false);
+          await scope.openReaderWindowSetup(selection, true, false);
         },
         { selection: testCase.text },
       );


### PR DESCRIPTION
- Updated `selection-loader.ts` to always fetch current selection from the background, removing persistence logic.
- Simplified `openReaderWindowSetup` function by removing the `saveToLocal` parameter.
- Cleaned up `selection.ts` by removing unused selection persistence functions.
- Revised documentation in `architecture.md` to clarify selection and preference handling.
- Adjusted related tests to reflect changes in function signatures and behavior.