### PR TITLE
Add page-wide content extraction and popup control

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Simply select text on a webpage, right-click and select `10x your reading speed 
 
 Prefer to paste something manually? Click the extension icon, drop your text into the popup, and then press **Speed read it** to open the reader with that content.
 
+No selection handy? Hit **Speed read this page** to automatically detect the primary article content on the active tab and launch it in the reader.
+
 ## What makes this special
 
 On top of traditional **Rapid Serial Visual Presentation** (RSVP), we've added **LLM pre-processing** to further accelerate your reading comprehension. Studies show that the habit of internally "sounding out" (sub-vocalising) words is a limiting factor that prevents faster reading speeds. RSVP eliminates this by not displaying words long enough for sub-vocalisation to occur.
@@ -30,6 +32,7 @@ Our AI preprocessing optimizes text before presentation, allowing you to absorb 
 > **Multi-browser support** (Chrome, Firefox, Safari)
 > **AI-powered text preprocessing** for enhanced comprehension
 > Keyboard shortcut helper that nudges you to select text when none is highlighted
+> Automatic article extraction for one-click “read this page” sessions
 
 ## Table of Contents
 

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -57,7 +57,7 @@ export async function handleBackgroundMessage (
         return true
       }
 
-      await openReaderWindowSetup(providedText, true, false)
+      await openReaderWindowSetup(providedText, true, Boolean(message.dirRTL))
       // Informational: reader opened from popup
       return true
     }

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -19,6 +19,7 @@ export type BackgroundMessage =
       selectionText?: string;
       wordsPerMinute: number;
       theme?: ReaderTheme;
+      dirRTL?: boolean;
     }
   | {
       target: 'background';
@@ -69,6 +70,10 @@ export type ContentRequest =
   | {
       target: 'content';
       type: 'hideSelectionHint';
+    }
+  | {
+      target: 'content';
+      type: 'collectReadableContent';
     };
 
 export type RuntimeMessage = BackgroundMessage | ReaderMessage | ContentRequest;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,6 +1,7 @@
 import { getBrowser } from '../platform/browser'
 import type { BackgroundMessage, ContentRequest } from '../common/messages'
 import { DEFAULTS } from '../config/defaults'
+import { collectReadableContent } from './readable-content'
 
 const browser = getBrowser()
 
@@ -137,6 +138,11 @@ browser.runtime.onMessage.addListener((rawMessage: ContentRequest, _sender: chro
     case 'hideSelectionHint':
       removeSelectionHint()
       return true
+    case 'collectReadableContent': {
+      const result = collectReadableContent()
+      sendResponse(result ?? { text: '', isRTL: false, wordCount: 0 })
+      return true
+    }
     default:
       return undefined
   }

--- a/src/content/readable-content.ts
+++ b/src/content/readable-content.ts
@@ -1,0 +1,221 @@
+const MIN_PARAGRAPH_LENGTH = 60
+const MIN_TEXT_LENGTH = 600
+const MIN_WORD_COUNT = 120
+const FALLBACK_MIN_WORD_COUNT = 90
+const MAX_PARAGRAPHS = 30
+const BLOCKED_SELECTORS = 'header, footer, nav, aside, form, [role="banner"], [role="navigation"], [role="search"], [role="complementary"], [role="contentinfo"]'
+const CANDIDATE_SELECTORS = [
+  'article',
+  'main',
+  '[role="main"]',
+  'div[itemprop="articleBody"]',
+  '.article',
+  '.post',
+  '.entry-content',
+  '.blog-post',
+  '#content',
+  '#main'
+]
+
+export type ReadableContent = {
+  text: string;
+  wordCount: number;
+  isRTL: boolean;
+}
+
+type CandidateScore = {
+  text: string;
+  score: number;
+  wordCount: number;
+}
+
+function normaliseParagraphs (rawText: string): string[] {
+  const lines = rawText.split(/\n+/)
+  const paragraphs: string[] = []
+  let buffer: string[] = []
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) {
+      if (buffer.length > 0) {
+        paragraphs.push(buffer.join(' '))
+        buffer = []
+      }
+      continue
+    }
+
+    buffer.push(trimmed.replace(/\s+/g, ' '))
+  }
+
+  if (buffer.length > 0) {
+    paragraphs.push(buffer.join(' '))
+  }
+
+  return paragraphs
+}
+
+function isElementVisible (element: Element): boolean {
+  if (!(element instanceof HTMLElement)) {
+    return false
+  }
+
+  if (element.hidden || element.getAttribute('aria-hidden') === 'true') {
+    return false
+  }
+
+  const style = window.getComputedStyle(element)
+  if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) {
+    return false
+  }
+
+  const rect = element.getBoundingClientRect()
+  return rect.width > 1 && rect.height > 1
+}
+
+function isBlocked (element: Element | null): boolean {
+  if (!element || !(element instanceof HTMLElement)) {
+    return false
+  }
+
+  return element.matches(BLOCKED_SELECTORS)
+}
+
+function addCandidate (candidates: Set<HTMLElement>, element: HTMLElement | null): void {
+  if (!element || isBlocked(element) || !isElementVisible(element)) {
+    return
+  }
+
+  candidates.add(element)
+}
+
+function collectFromSelectors (candidates: Set<HTMLElement>): void {
+  for (const selector of CANDIDATE_SELECTORS) {
+    for (const element of document.querySelectorAll<HTMLElement>(selector)) {
+      addCandidate(candidates, element)
+    }
+  }
+}
+
+function collectFromParagraphs (candidates: Set<HTMLElement>): void {
+  const paragraphs = Array.from(document.querySelectorAll<HTMLElement>('p'))
+    .filter((paragraph) => paragraph.innerText.trim().length >= MIN_PARAGRAPH_LENGTH)
+    .slice(0, MAX_PARAGRAPHS * 3)
+
+  for (const paragraph of paragraphs) {
+    let current: HTMLElement | null = paragraph
+    for (let depth = 0; current && depth < 3; depth += 1) {
+      addCandidate(candidates, current)
+      current = current.parentElement
+    }
+  }
+}
+
+function gatherCandidateElements (): HTMLElement[] {
+  const candidates = new Set<HTMLElement>()
+
+  collectFromSelectors(candidates)
+  collectFromParagraphs(candidates)
+
+  if (document.body) {
+    addCandidate(candidates, document.body)
+  }
+
+  return Array.from(candidates)
+}
+
+function calculateScore (element: HTMLElement): CandidateScore | null {
+  const rawText = element.innerText
+  const paragraphs = normaliseParagraphs(rawText).filter((paragraph) => paragraph.length >= MIN_PARAGRAPH_LENGTH)
+  if (paragraphs.length === 0) {
+    return null
+  }
+
+  const combinedText = paragraphs.join('\n\n')
+  if (combinedText.length < MIN_TEXT_LENGTH) {
+    return null
+  }
+
+  const wordCount = combinedText.split(/\s+/).filter(Boolean).length
+  if (wordCount < MIN_WORD_COUNT) {
+    return null
+  }
+
+  const linkTextLength = Array.from(element.querySelectorAll('a'))
+    .map((anchor) => anchor.innerText.trim().length)
+    .reduce((acc, length) => acc + length, 0)
+
+  const linkDensity = linkTextLength / Math.max(combinedText.length, 1)
+  if (linkDensity > 0.4) {
+    return null
+  }
+
+  const headingCount = element.querySelectorAll('h1, h2, h3').length
+  const paragraphScore = paragraphs.length * 150
+  const headingBoost = headingCount * 60
+  const score = (combinedText.length + paragraphScore + headingBoost) * (1 - linkDensity * 0.5)
+
+  return {
+    text: combinedText,
+    score,
+    wordCount
+  }
+}
+
+function detectDirection (text: string): boolean {
+  const rtlChar = /[\u0590-\u08FF\uFB1D-\uFDFD\uFE70-\uFEFC]/u
+  return rtlChar.test(text)
+}
+
+function fallbackContent (): ReadableContent | null {
+  if (!document.body) {
+    return null
+  }
+
+  const paragraphs = normaliseParagraphs(document.body.innerText)
+    .filter((paragraph) => paragraph.length >= MIN_PARAGRAPH_LENGTH)
+    .slice(0, MAX_PARAGRAPHS)
+
+  if (paragraphs.length === 0) {
+    return null
+  }
+
+  const combined = paragraphs.join('\n\n')
+  const wordCount = combined.split(/\s+/).filter(Boolean).length
+
+  if (wordCount < FALLBACK_MIN_WORD_COUNT) {
+    return null
+  }
+
+  return {
+    text: combined,
+    wordCount,
+    isRTL: detectDirection(combined)
+  }
+}
+
+export function collectReadableContent (): ReadableContent | null {
+  const candidates = gatherCandidateElements()
+  let best: CandidateScore | null = null
+
+  for (const element of candidates) {
+    const evaluated = calculateScore(element)
+    if (!evaluated) {
+      continue
+    }
+
+    if (!best || evaluated.score > best.score) {
+      best = evaluated
+    }
+  }
+
+  if (best) {
+    return {
+      text: best.text,
+      wordCount: best.wordCount,
+      isRTL: detectDirection(best.text)
+    }
+  }
+
+  return fallbackContent()
+}
+

--- a/static/pages/popup.html
+++ b/static/pages/popup.html
@@ -25,7 +25,10 @@
           />
         </label>
       </section>
+      <div class="popup__actions">
         <button id="speedReadButton" class="popup__speed-read-button" disabled>Speed read it</button>
+        <button id="speedReadPageButton" class="popup__speed-read-button popup__speed-read-button--secondary">Speed read this page</button>
+      </div>
     </main>
     <footer class="popup__footer">
       <a href="https://speed-reader.com" target="_blank" rel="noreferrer">Help &amp; Support</a>

--- a/static/styles/popup.css
+++ b/static/styles/popup.css
@@ -67,6 +67,13 @@ body.popup--light {
   margin-top: 16px;
 }
 
+.popup__actions {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .popup__description {
   margin: 0 0 16px 0;
   line-height: 1.5;
@@ -149,6 +156,15 @@ body.popup--light {
   background: rgba(255, 255, 255, 0.1);
   color: rgba(245, 246, 247, 0.4);
   cursor: not-allowed;
+}
+
+.popup__speed-read-button--secondary:enabled {
+  background: linear-gradient(135deg, #f97316, #fb923c);
+  box-shadow: var(--popup-button-shadow);
+}
+
+.popup__speed-read-button--secondary:enabled:hover {
+  background: linear-gradient(135deg, #ea580c, #f97316);
 }
 
 .popup__footer {


### PR DESCRIPTION
## Summary
- add a content-script extraction module that scores visible article containers and falls back to paragraph heuristics
- expose a new popup action that requests readable content from the active tab, opens the reader, and handles rtl text
- refresh the popup markup/styles and README to document the new "Speed read this page" capability

## Testing
- npm run lint
- npm run typecheck
- xvfb-run -a npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfd41edcb883218b3f1d85cf06c67b